### PR TITLE
revert to v2.3.0

### DIFF
--- a/chains/terraclassic-mainnet/upgrades.yml
+++ b/chains/terraclassic-mainnet/upgrades.yml
@@ -48,10 +48,10 @@ versions:
       linux/arm64: >-
         https://github.com/terra-money/classic-core/releases/download/v2.2.1/terra_2.2.1_Linux_arm64.tar.gz?checksum=sha256:86d457e2a6ee819e1526f41bb80e2be7911798d35ebaedb698aea66e1ff9ecd7
   - name: v6
-    alias: '2.3.1'
+    alias: '2.3.0'
     height: '15493370'
     proposal: '11874'
-    tag: v2.3.1
+    tag: v2.3.0
     binaries:
       linux/amd64: >-
-        https://github.com/classic-terra/core/releases/download/v2.3.1/terra_2.3.1_Linux_x86_64.tar.gz?checksum=sha256:75b133e60ce6e4605cc487b351cb78a7ed4464080de91ec9363e04f12fcc11a0
+        https://github.com/terra-money/classic-core/releases/download/v2.3.0/terra_2.3.0_Linux_x86_64.tar.gz?checksum=sha256:03a788fb401f86c663243346df19f95ceaf98881bb2d84ea385d293d91598aa7


### PR DESCRIPTION
Version v2.3.1 is consensus breaking. Reverting to v2.3.0

{"level":"info","module":"consensus","hash":"&\ufffd\u0017\ufffd\ufffd\ufffd\rC\ufffd\u001eH2\ufffd\ufffdCQ.\ufffd\ufffd\u0011\ufffd\ufffd\ufffd\ufffdP\ufffd\ufffd\ufffd`K\r\u001f","height":15602899,"protocol-version":0,"software-version":"2.3.1","time":"2023-11-28T04:01:37Z","message":"ABCI Handshake App Info"}

{"level":"info","commit":"436F6D6D697449447B5B3133322036302031373620383020323530203233302031353620323134203230352032303120323137203632203137392039322038332031353720313231203638203833203132382031393220313638203733203232382031313320313730203232312033342031333620313233203231352032375D3A4545313444347D","time":"2023-11-28T04:01:44Z","message":"commit synced"}
{"level":"info","module":"state","app_hash":"843CB050FAE69CD6CDC9D93EB35C539D79445380C0A849E471AADD22887BD71B","height":15602900,"num_txs":23,"time":"2023-11-28T04:01:44Z","message":"committed state"}
{"level":"error","module":"blockchain","err":"wrong Block.Header.LastResultsHash.  Expected 36A745AE5BBEB65CEFDD40E4E03B71E9F67B0E1163F873291F8424ACF95360C1, got 1C9D699D1454E52DC5770865863D6E82595AF79BCFE29CD60365AE40EC444D87","time":"2023-11-28T04:01:44Z","message":"Error in validation"}
{"level":"error","module":"p2p","err":"blockchainReactor validation error: wrong Block.Header.LastResultsHash.  Expected 36A745AE5BBEB65CEFDD40E4E03B71E9F67B0E1163F873291F8424ACF95360C1, got 1C9D699D1454E52DC5770865863D6E82595AF79BCFE29CD60365AE40EC444D87","peer":{"Logger":{},"Data":{}},"time":"2023-11-28T04:01:44Z","message":"Stopping peer for error"}
{