### PR TITLE
FOUND-402 - fix snapshot service

### DIFF
--- a/bin/snapshotservice.py
+++ b/bin/snapshotservice.py
@@ -27,12 +27,12 @@ def is_ready():
     if not (start <= datetime.utcnow().time() < stop):
         write_stderr(f"Current time is not between {start} and {stop} UTC.")
         return False
-    
+
     status = getstatus.get_status('http://localhost:26657/status')
-    if not getstatus.is_catching_up(status):
-        write_stderr(f"Node is not catching up.")
+    if getstatus.is_catching_up(status):
+        write_stderr(f"Node is still catching up.")
         return False
-    
+
     return True
 
 def main(snapshots_dir, data_dir, cosmprund_enabled):


### PR DESCRIPTION
Snapshot service is still broken. There are no snapshots created between 5-6AM UTC as they should.
I believe root cause is this part:
```
    status = getstatus.get_status('http://localhost:26657/status')
    if not getstatus.is_catching_up(status):
        write_stderr(f"Node is not catching up.")
        return False
```
Logic behind this part is wrong. When node is not catching up, its ready to take snapshot (it’s good). This part works opposite site - it refuses to create snaphot when node is fine, but creates snapshot when node is behind.